### PR TITLE
core: fix implicit capturing of current object

### DIFF
--- a/includes/cpp_redis/core/client.hpp
+++ b/includes/cpp_redis/core/client.hpp
@@ -236,7 +236,7 @@ namespace cpp_redis {
 				std::unique_lock<std::mutex> lock_callback(m_callbacks_mutex);
 				__CPP_REDIS_LOG(debug, "cpp_redis::client waiting for callbacks to complete");
 				if (!m_sync_condvar.wait_for(lock_callback, timeout,
-				                             [=] { return m_callbacks_running == 0 && m_commands.empty(); })) {
+				                             [=, this] { return m_callbacks_running == 0 && m_commands.empty(); })) {
 					__CPP_REDIS_LOG(debug, "cpp_redis::client finished waiting for callback");
 				} else {
 					__CPP_REDIS_LOG(debug, "cpp_redis::client timed out waiting for callback");

--- a/includes/cpp_redis/core/sentinel.hpp
+++ b/includes/cpp_redis/core/sentinel.hpp
@@ -132,7 +132,7 @@ namespace cpp_redis {
 
 				std::unique_lock<std::mutex> lock_callback(m_callbacks_mutex);
 				__CPP_REDIS_LOG(debug, "cpp_redis::sentinel waiting for callbacks to complete");
-				if (!m_sync_condvar.wait_for(lock_callback, timeout, [=] {
+				if (!m_sync_condvar.wait_for(lock_callback, timeout, [=, this] {
 						return m_callbacks_running == 0 && m_callbacks.empty();
 				})) {
 					__CPP_REDIS_LOG(debug, "cpp_redis::sentinel finished waiting for callback");

--- a/sources/core/client.cpp
+++ b/sources/core/client.cpp
@@ -226,7 +226,7 @@ namespace cpp_redis {
 
 		std::unique_lock<std::mutex> lock_callback(m_callbacks_mutex);
 		__CPP_REDIS_LOG(debug, "cpp_redis::client waiting for callbacks to complete");
-		m_sync_condvar.wait(lock_callback, [=] { return m_callbacks_running == 0 && m_commands.empty(); });
+		m_sync_condvar.wait(lock_callback, [=, this] { return m_callbacks_running == 0 && m_commands.empty(); });
 		__CPP_REDIS_LOG(debug, "cpp_redis::client finished waiting for callback completion");
 		return *this;
 	}
@@ -288,7 +288,7 @@ namespace cpp_redis {
 
 		m_callbacks_running += __CPP_REDIS_LENGTH(commands.size());
 
-		std::thread t([=]() mutable {
+		std::thread t([=, this]() mutable {
 				while (!commands.empty()) {
 					const auto &callback = commands.front().callback;
 
@@ -3387,392 +3387,392 @@ namespace cpp_redis {
 
 	std::future<reply>
 	client::send(const std::vector<std::string> &redis_cmd) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return send(redis_cmd, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return send(redis_cmd, cb); });
 	}
 
 	std::future<reply>
 	client::append(const std::string &key, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return append(key, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return append(key, value, cb); });
 	}
 
 	std::future<reply>
 	client::auth(const std::string &password) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return auth(password, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return auth(password, cb); });
 	}
 
 	std::future<reply>
 	client::bgrewriteaof() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bgrewriteaof(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return bgrewriteaof(cb); });
 	}
 
 	std::future<reply>
 	client::bgsave() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bgsave(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return bgsave(cb); });
 	}
 
 	std::future<reply>
 	client::bitcount(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitcount(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return bitcount(key, cb); });
 	}
 
 	std::future<reply>
 	client::bitcount(const std::string &key, int start, int end) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitcount(key, start, end, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return bitcount(key, start, end, cb); });
 	}
 
 	std::future<reply>
 	client::bitfield(const std::string &key, const std::vector<bitfield_operation> &operations) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitfield(key, operations, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return bitfield(key, operations, cb); });
 	}
 
 	std::future<reply>
 	client::bitop(const std::string &operation, const std::string &destkey, const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitop(operation, destkey, keys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return bitop(operation, destkey, keys, cb); });
 	}
 
 	std::future<reply>
 	client::bitpos(const std::string &key, int bit) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitpos(key, bit, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return bitpos(key, bit, cb); });
 	}
 
 	std::future<reply>
 	client::bitpos(const std::string &key, int bit, int start) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitpos(key, bit, start, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return bitpos(key, bit, start, cb); });
 	}
 
 	std::future<reply>
 	client::bitpos(const std::string &key, int bit, int start, int end) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitpos(key, bit, start, end, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return bitpos(key, bit, start, end, cb); });
 	}
 
 	std::future<reply>
 	client::blpop(const std::vector<std::string> &keys, int timeout) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return blpop(keys, timeout, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return blpop(keys, timeout, cb); });
 	}
 
 	std::future<reply>
 	client::brpop(const std::vector<std::string> &keys, int timeout) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return brpop(keys, timeout, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return brpop(keys, timeout, cb); });
 	}
 
 	std::future<reply>
 	client::brpoplpush(const std::string &src, const std::string &dst, int timeout) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return brpoplpush(src, dst, timeout, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return brpoplpush(src, dst, timeout, cb); });
 	}
 
 	std::future<reply>
 	client::bzpopmin(const std::vector<std::string>& keys, int timeout) {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return bzpopmin(keys, timeout, cb); });
+		return exec_cmd([=, this](const reply_callback_t& cb) -> client& { return bzpopmin(keys, timeout, cb); });
 	}
 
 	std::future<reply>
 	client::bzpopmax(const std::vector<std::string>& keys, int timeout) {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return bzpopmax(keys, timeout, cb); });
+		return exec_cmd([=, this](const reply_callback_t& cb) -> client& { return bzpopmax(keys, timeout, cb); });
 	}
 
 	std::future<reply>
 	client::client_id() {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return client_id(cb); });
+		return exec_cmd([=, this](const reply_callback_t& cb) -> client& { return client_id(cb); });
 	}
 
 	std::future<reply>
 	client::client_list() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return client_list(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return client_list(cb); });
 	}
 
 	std::future<reply>
 	client::client_getname() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return client_getname(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return client_getname(cb); });
 	}
 
 	std::future<reply>
 	client::client_pause(int timeout) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return client_pause(timeout, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return client_pause(timeout, cb); });
 	}
 
 	std::future<reply>
 	client::client_reply(const std::string &mode) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return client_reply(mode, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return client_reply(mode, cb); });
 	}
 
 	std::future<reply>
 	client::client_setname(const std::string &name) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return client_setname(name, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return client_setname(name, cb); });
 	}
 
 	std::future<reply>
 	client::client_unblock(int id, bool witherror) {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return client_unblock(id, witherror, cb); });
+		return exec_cmd([=, this](const reply_callback_t& cb) -> client& { return client_unblock(id, witherror, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_addslots(const std::vector<std::string> &p_slots) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_addslots(p_slots, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_addslots(p_slots, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_count_failure_reports(const std::string &node_id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_count_failure_reports(node_id, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_count_failure_reports(node_id, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_countkeysinslot(const std::string &slot) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_countkeysinslot(slot, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_countkeysinslot(slot, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_delslots(const std::vector<std::string> &p_slots) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_delslots(p_slots, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_delslots(p_slots, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_failover() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_failover(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_failover(cb); });
 	}
 
 	std::future<reply>
 	client::cluster_failover(const std::string &mode) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_failover(mode, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_failover(mode, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_forget(const std::string &node_id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_forget(node_id, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_forget(node_id, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_getkeysinslot(const std::string &slot, int count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_getkeysinslot(slot, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_getkeysinslot(slot, count, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_info() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_info(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_info(cb); });
 	}
 
 	std::future<reply>
 	client::cluster_keyslot(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_keyslot(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_keyslot(key, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_meet(const std::string &ip, int port) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_meet(ip, port, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_meet(ip, port, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_nodes() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_nodes(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_nodes(cb); });
 	}
 
 	std::future<reply>
 	client::cluster_replicate(const std::string &node_id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_replicate(node_id, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_replicate(node_id, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_reset(const std::string &mode) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_reset(mode, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_reset(mode, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_saveconfig() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_saveconfig(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_saveconfig(cb); });
 	}
 
 	std::future<reply>
 	client::cluster_set_config_epoch(const std::string &epoch) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_set_config_epoch(epoch, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_set_config_epoch(epoch, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_setslot(const std::string &slot, const std::string &mode) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_setslot(slot, mode, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_setslot(slot, mode, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_setslot(const std::string &slot, const std::string &mode, const std::string &node_id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_setslot(slot, mode, node_id, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_setslot(slot, mode, node_id, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_slaves(const std::string &node_id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_slaves(node_id, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_slaves(node_id, cb); });
 	}
 
 	std::future<reply>
 	client::cluster_slots() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_slots(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return cluster_slots(cb); });
 	}
 
 	std::future<reply>
 	client::command() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return command(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return command(cb); });
 	}
 
 	std::future<reply>
 	client::command_count() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return command_count(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return command_count(cb); });
 	}
 
 	std::future<reply>
 	client::command_getkeys() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return command_getkeys(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return command_getkeys(cb); });
 	}
 
 	std::future<reply>
 	client::command_info(const std::vector<std::string> &command_name) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return command_info(command_name, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return command_info(command_name, cb); });
 	}
 
 	std::future<reply>
 	client::config_get(const std::string &param) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return config_get(param, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return config_get(param, cb); });
 	}
 
 	std::future<reply>
 	client::config_rewrite() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return config_rewrite(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return config_rewrite(cb); });
 	}
 
 	std::future<reply>
 	client::config_set(const std::string &param, const std::string &val) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return config_set(param, val, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return config_set(param, val, cb); });
 	}
 
 	std::future<reply>
 	client::config_resetstat() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return config_resetstat(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return config_resetstat(cb); });
 	}
 
 	std::future<reply>
 	client::dbsize() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return dbsize(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return dbsize(cb); });
 	}
 
 	std::future<reply>
 	client::debug_object(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return debug_object(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return debug_object(key, cb); });
 	}
 
 	std::future<reply>
 	client::debug_segfault() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return debug_segfault(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return debug_segfault(cb); });
 	}
 
 	std::future<reply>
 	client::decr(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return decr(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return decr(key, cb); });
 	}
 
 	std::future<reply>
 	client::decrby(const std::string &key, int val) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return decrby(key, val, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return decrby(key, val, cb); });
 	}
 
 	std::future<reply>
 	client::del(const std::vector<std::string> &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return del(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return del(key, cb); });
 	}
 
 	std::future<reply>
 	client::discard() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return discard(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return discard(cb); });
 	}
 
 	std::future<reply>
 	client::dump(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return dump(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return dump(key, cb); });
 	}
 
 	std::future<reply>
 	client::echo(const std::string &msg) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return echo(msg, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return echo(msg, cb); });
 	}
 
 	std::future<reply>
 	client::eval(const std::string &script, int numkeys, const std::vector<std::string> &keys,
 	             const std::vector<std::string> &args) {
 		(void) numkeys;
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return eval(script, keys, args, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return eval(script, keys, args, cb); });
 	}
 
 	std::future<reply>
 	client::eval(const std::string &script, const std::vector<std::string> &keys,
 	             const std::vector<std::string> &args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return eval(script, keys, args, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return eval(script, keys, args, cb); });
 	}
 
 	std::future<reply>
 	client::evalsha(const std::string &sha1, const std::vector<std::string> &keys,
 	                const std::vector<std::string> &args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return evalsha(sha1, keys, args, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return evalsha(sha1, keys, args, cb); });
 	}
 
 	std::future<reply>
 	client::evalsha(const std::string &sha1, int numkeys, const std::vector<std::string> &keys,
 	                const std::vector<std::string> &args) {
 		(void) numkeys;
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return evalsha(sha1, keys, args, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return evalsha(sha1, keys, args, cb); });
 	}
 
 	std::future<reply>
 	client::exec() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return exec(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return exec(cb); });
 	}
 
 	std::future<reply>
 	client::exists(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return exists(keys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return exists(keys, cb); });
 	}
 
 	std::future<reply>
 	client::expire(const std::string &key, int seconds) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return expire(key, seconds, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return expire(key, seconds, cb); });
 	}
 
 	std::future<reply>
 	client::expireat(const std::string &key, int timestamp) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return expireat(key, timestamp, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return expireat(key, timestamp, cb); });
 	}
 
 	std::future<reply>
 	client::flushall() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return flushall(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return flushall(cb); });
 	}
 
 	std::future<reply>
 	client::flushdb() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return flushdb(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return flushdb(cb); });
 	}
 
 	std::future<reply>
 	client::geoadd(const std::string &key,
 	               const std::vector<std::tuple<std::string, std::string, std::string>> &long_lat_memb) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return geoadd(key, long_lat_memb, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return geoadd(key, long_lat_memb, cb); });
 	}
 
 	std::future<reply>
 	client::geohash(const std::string &key, const std::vector<std::string> &members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return geohash(key, members, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return geohash(key, members, cb); });
 	}
 
 	std::future<reply>
 	client::geopos(const std::string &key, const std::vector<std::string> &members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return geopos(key, members, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return geopos(key, members, cb); });
 	}
 
 	std::future<reply>
 	client::geodist(const std::string &key, const std::string &member_1, const std::string &member_2,
 	                const std::string &unit) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return geodist(key, member_1, member_2, unit, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return geodist(key, member_1, member_2, unit, cb); });
 	}
 
 	std::future<reply>
 	client::georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
 	                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
 	                  const std::string &store_key, const std::string &storedist_key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, count,
 				                 store_key, storedist_key, cb);
 		});
@@ -3782,7 +3782,7 @@ namespace cpp_redis {
 	client::georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
 	                          bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
 	                          const std::string &store_key, const std::string &storedist_key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, count,
 				                         store_key, storedist_key, cb);
 		});
@@ -3790,538 +3790,538 @@ namespace cpp_redis {
 
 	std::future<reply>
 	client::get(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return get(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return get(key, cb); });
 	}
 
 	std::future<reply>
 	client::getbit(const std::string &key, int offset) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return getbit(key, offset, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return getbit(key, offset, cb); });
 	}
 
 	std::future<reply>
 	client::getrange(const std::string &key, int start, int end) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return getrange(key, start, end, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return getrange(key, start, end, cb); });
 	}
 
 	std::future<reply>
 	client::getset(const std::string &key, const std::string &val) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return getset(key, val, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return getset(key, val, cb); });
 	}
 
 	std::future<reply>
 	client::hdel(const std::string &key, const std::vector<std::string> &fields) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hdel(key, fields, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hdel(key, fields, cb); });
 	}
 
 	std::future<reply>
 	client::hexists(const std::string &key, const std::string &field) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hexists(key, field, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hexists(key, field, cb); });
 	}
 
 	std::future<reply>
 	client::hget(const std::string &key, const std::string &field) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hget(key, field, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hget(key, field, cb); });
 	}
 
 	std::future<reply>
 	client::hgetall(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hgetall(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hgetall(key, cb); });
 	}
 
 	std::future<reply>
 	client::hincrby(const std::string &key, const std::string &field, int incr) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hincrby(key, field, incr, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hincrby(key, field, incr, cb); });
 	}
 
 	std::future<reply>
 	client::hincrbyfloat(const std::string &key, const std::string &field, float incr) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hincrbyfloat(key, field, incr, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hincrbyfloat(key, field, incr, cb); });
 	}
 
 	std::future<reply>
 	client::hkeys(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hkeys(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hkeys(key, cb); });
 	}
 
 	std::future<reply>
 	client::hlen(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hlen(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hlen(key, cb); });
 	}
 
 	std::future<reply>
 	client::hmget(const std::string &key, const std::vector<std::string> &fields) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hmget(key, fields, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hmget(key, fields, cb); });
 	}
 
 	std::future<reply>
 	client::hmset(const std::string &key, const std::vector<std::pair<std::string, std::string>> &field_val) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hmset(key, field_val, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hmset(key, field_val, cb); });
 	}
 
 	std::future<reply>
 	client::hscan(const std::string &key, std::size_t cursor) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hscan(key, cursor, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hscan(key, cursor, cb); });
 	}
 
 	std::future<reply>
 	client::hscan(const std::string &key, std::size_t cursor, const std::string &pattern) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hscan(key, cursor, pattern, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hscan(key, cursor, pattern, cb); });
 	}
 
 	std::future<reply>
 	client::hscan(const std::string &key, std::size_t cursor, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hscan(key, cursor, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hscan(key, cursor, count, cb); });
 	}
 
 	std::future<reply>
 	client::hscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hscan(key, cursor, pattern, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hscan(key, cursor, pattern, count, cb); });
 	}
 
 	std::future<reply>
 	client::hset(const std::string &key, const std::string &field, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hset(key, field, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hset(key, field, value, cb); });
 	}
 
 	std::future<reply>
 	client::hsetnx(const std::string &key, const std::string &field, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hsetnx(key, field, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hsetnx(key, field, value, cb); });
 	}
 
 	std::future<reply>
 	client::hstrlen(const std::string &key, const std::string &field) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hstrlen(key, field, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hstrlen(key, field, cb); });
 	}
 
 	std::future<reply>
 	client::hvals(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hvals(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return hvals(key, cb); });
 	}
 
 	std::future<reply>
 	client::incr(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return incr(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return incr(key, cb); });
 	}
 
 	std::future<reply>
 	client::incrby(const std::string &key, int incr) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return incrby(key, incr, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return incrby(key, incr, cb); });
 	}
 
 	std::future<reply>
 	client::incrbyfloat(const std::string &key, float incr) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return incrbyfloat(key, incr, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return incrbyfloat(key, incr, cb); });
 	}
 
 	std::future<reply>
 	client::info(const std::string &section) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return info(section, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return info(section, cb); });
 	}
 
 	std::future<reply>
 	client::keys(const std::string &pattern) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return keys(pattern, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return keys(pattern, cb); });
 	}
 
 	std::future<reply>
 	client::lastsave() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lastsave(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return lastsave(cb); });
 	}
 
 	std::future<reply>
 	client::lindex(const std::string &key, int index) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lindex(key, index, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return lindex(key, index, cb); });
 	}
 
 	std::future<reply>
 	client::linsert(const std::string &key, const std::string &before_after, const std::string &pivot,
 	                const std::string &value) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return linsert(key, before_after, pivot, value, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return linsert(key, before_after, pivot, value, cb); });
 	}
 
 	std::future<reply>
 	client::llen(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return llen(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return llen(key, cb); });
 	}
 
 	std::future<reply>
 	client::lpop(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lpop(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return lpop(key, cb); });
 	}
 
 	std::future<reply>
 	client::lpush(const std::string &key, const std::vector<std::string> &values) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lpush(key, values, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return lpush(key, values, cb); });
 	}
 
 	std::future<reply>
 	client::lpushx(const std::string &key, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lpushx(key, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return lpushx(key, value, cb); });
 	}
 
 	std::future<reply>
 	client::lrange(const std::string &key, int start, int stop) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lrange(key, start, stop, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return lrange(key, start, stop, cb); });
 	}
 
 	std::future<reply>
 	client::lrem(const std::string &key, int count, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lrem(key, count, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return lrem(key, count, value, cb); });
 	}
 
 	std::future<reply>
 	client::lset(const std::string &key, int index, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lset(key, index, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return lset(key, index, value, cb); });
 	}
 
 	std::future<reply>
 	client::ltrim(const std::string &key, int start, int stop) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return ltrim(key, start, stop, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return ltrim(key, start, stop, cb); });
 	}
 
 	std::future<reply>
 	client::mget(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return mget(keys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return mget(keys, cb); });
 	}
 
 	std::future<reply>
 	client::migrate(const std::string &host, int port, const std::string &key, const std::string &dest_db, int timeout,
 	                bool copy, bool replace, const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return migrate(host, port, key, dest_db, timeout, copy, replace, keys, cb);
 		});
 	}
 
 	std::future<reply>
 	client::monitor() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return monitor(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return monitor(cb); });
 	}
 
 	std::future<reply>
 	client::move(const std::string &key, const std::string &db) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return move(key, db, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return move(key, db, cb); });
 	}
 
 	std::future<reply>
 	client::mset(const std::vector<std::pair<std::string, std::string>> &key_vals) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return mset(key_vals, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return mset(key_vals, cb); });
 	}
 
 	std::future<reply>
 	client::msetnx(const std::vector<std::pair<std::string, std::string>> &key_vals) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return msetnx(key_vals, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return msetnx(key_vals, cb); });
 	}
 
 	std::future<reply>
 	client::multi() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return multi(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return multi(cb); });
 	}
 
 	std::future<reply>
 	client::object(const std::string &subcommand, const std::vector<std::string> &args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return object(subcommand, args, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return object(subcommand, args, cb); });
 	}
 
 	std::future<reply>
 	client::persist(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return persist(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return persist(key, cb); });
 	}
 
 	std::future<reply>
 	client::pexpire(const std::string &key, int ms) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pexpire(key, ms, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return pexpire(key, ms, cb); });
 	}
 
 	std::future<reply>
 	client::pexpireat(const std::string &key, int ms_timestamp) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pexpireat(key, ms_timestamp, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return pexpireat(key, ms_timestamp, cb); });
 	}
 
 	std::future<reply>
 	client::pfadd(const std::string &key, const std::vector<std::string> &elements) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pfadd(key, elements, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return pfadd(key, elements, cb); });
 	}
 
 	std::future<reply>
 	client::pfcount(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pfcount(keys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return pfcount(keys, cb); });
 	}
 
 	std::future<reply>
 	client::pfmerge(const std::string &destkey, const std::vector<std::string> &sourcekeys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pfmerge(destkey, sourcekeys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return pfmerge(destkey, sourcekeys, cb); });
 	}
 
 	std::future<reply>
 	client::ping() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return ping(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return ping(cb); });
 	}
 
 	std::future<reply>
 	client::ping(const std::string &message) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return ping(message, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return ping(message, cb); });
 	}
 
 	std::future<reply>
 	client::psetex(const std::string &key, int64_t ms, const std::string &val) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return psetex(key, ms, val, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return psetex(key, ms, val, cb); });
 	}
 
 	std::future<reply>
 	client::publish(const std::string &channel, const std::string &message) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return publish(channel, message, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return publish(channel, message, cb); });
 	}
 
 	std::future<reply>
 	client::pubsub(const std::string &subcommand, const std::vector<std::string> &args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pubsub(subcommand, args, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return pubsub(subcommand, args, cb); });
 	}
 
 	std::future<reply>
 	client::pttl(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pttl(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return pttl(key, cb); });
 	}
 
 	std::future<reply>
 	client::quit() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return quit(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return quit(cb); });
 	}
 
 	std::future<reply>
 	client::randomkey() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return randomkey(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return randomkey(cb); });
 	}
 
 	std::future<reply>
 	client::readonly() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return readonly(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return readonly(cb); });
 	}
 
 	std::future<reply>
 	client::readwrite() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return readwrite(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return readwrite(cb); });
 	}
 
 	std::future<reply>
 	client::rename(const std::string &key, const std::string &newkey) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return rename(key, newkey, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return rename(key, newkey, cb); });
 	}
 
 	std::future<reply>
 	client::renamenx(const std::string &key, const std::string &newkey) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return renamenx(key, newkey, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return renamenx(key, newkey, cb); });
 	}
 
 	std::future<reply>
 	client::restore(const std::string &key, int ttl, const std::string &serialized_value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return restore(key, ttl, serialized_value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return restore(key, ttl, serialized_value, cb); });
 	}
 
 	std::future<reply>
 	client::restore(const std::string &key, int ttl, const std::string &serialized_value, const std::string &replace) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return restore(key, ttl, serialized_value, replace, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return restore(key, ttl, serialized_value, replace, cb); });
 	}
 
 	std::future<reply>
 	client::role() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return role(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return role(cb); });
 	}
 
 	std::future<reply>
 	client::rpop(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return rpop(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return rpop(key, cb); });
 	}
 
 	std::future<reply>
 	client::rpoplpush(const std::string &src, const std::string &dst) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return rpoplpush(src, dst, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return rpoplpush(src, dst, cb); });
 	}
 
 	std::future<reply>
 	client::rpush(const std::string &key, const std::vector<std::string> &values) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return rpush(key, values, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return rpush(key, values, cb); });
 	}
 
 	std::future<reply>
 	client::rpushx(const std::string &key, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return rpushx(key, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return rpushx(key, value, cb); });
 	}
 
 	std::future<reply>
 	client::sadd(const std::string &key, const std::vector<std::string> &members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sadd(key, members, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sadd(key, members, cb); });
 	}
 
 	std::future<reply>
 	client::scan(std::size_t cursor) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return scan(cursor, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return scan(cursor, cb); });
 	}
 
 	std::future<reply>
 	client::scan(std::size_t cursor, const std::string &pattern) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return scan(cursor, pattern, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return scan(cursor, pattern, cb); });
 	}
 
 	std::future<reply>
 	client::scan(std::size_t cursor, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return scan(cursor, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return scan(cursor, count, cb); });
 	}
 
 	std::future<reply>
 	client::scan(std::size_t cursor, const std::string &pattern, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return scan(cursor, pattern, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return scan(cursor, pattern, count, cb); });
 	}
 
 	std::future<reply>
 	client::save() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return save(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return save(cb); });
 	}
 
 	std::future<reply>
 	client::scard(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return scard(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return scard(key, cb); });
 	}
 
 	std::future<reply>
 	client::script_debug(const std::string &mode) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return script_debug(mode, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return script_debug(mode, cb); });
 	}
 
 	std::future<reply>
 	client::script_exists(const std::vector<std::string> &scripts) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return script_exists(scripts, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return script_exists(scripts, cb); });
 	}
 
 	std::future<reply>
 	client::script_flush() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return script_flush(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return script_flush(cb); });
 	}
 
 	std::future<reply>
 	client::script_kill() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return script_kill(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return script_kill(cb); });
 	}
 
 	std::future<reply>
 	client::script_load(const std::string &script) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return script_load(script, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return script_load(script, cb); });
 	}
 
 	std::future<reply>
 	client::sdiff(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sdiff(keys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sdiff(keys, cb); });
 	}
 
 	std::future<reply>
 	client::sdiffstore(const std::string &dst, const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sdiffstore(dst, keys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sdiffstore(dst, keys, cb); });
 	}
 
 	std::future<reply>
 	client::select(int index) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return select(index, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return select(index, cb); });
 	}
 
 	std::future<reply>
 	client::set(const std::string &key, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return set(key, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return set(key, value, cb); });
 	}
 
 	std::future<reply>
 	client::set_advanced(const std::string &key, const std::string &value, bool ex, int ex_sec, bool px, int px_milli,
 	                     bool nx, bool xx) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return set_advanced(key, value, ex, ex_sec, px, px_milli, nx, xx, cb);
 		});
 	}
 
 	std::future<reply>
 	client::setbit_(const std::string &key, int offset, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return setbit_(key, offset, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return setbit_(key, offset, value, cb); });
 	}
 
 	std::future<reply>
 	client::setex(const std::string &key, int64_t seconds, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return setex(key, seconds, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return setex(key, seconds, value, cb); });
 	}
 
 	std::future<reply>
 	client::setnx(const std::string &key, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return setnx(key, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return setnx(key, value, cb); });
 	}
 
 	std::future<reply>
 	client::setrange(const std::string &key, int offset, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return setrange(key, offset, value, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return setrange(key, offset, value, cb); });
 	}
 
 	std::future<reply>
 	client::shutdown() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return shutdown(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return shutdown(cb); });
 	}
 
 	std::future<reply>
 	client::shutdown(const std::string &save) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return shutdown(save, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return shutdown(save, cb); });
 	}
 
 	std::future<reply>
 	client::sinter(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sinter(keys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sinter(keys, cb); });
 	}
 
 	std::future<reply>
 	client::sinterstore(const std::string &dst, const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sinterstore(dst, keys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sinterstore(dst, keys, cb); });
 	}
 
 	std::future<reply>
 	client::sismember(const std::string &key, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sismember(key, member, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sismember(key, member, cb); });
 	}
 
 	std::future<reply>
 	client::slaveof(const std::string &host, int port) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return slaveof(host, port, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return slaveof(host, port, cb); });
 	}
 
 	std::future<reply>
 	client::slowlog(const std::string &subcommand) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return slowlog(subcommand, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return slowlog(subcommand, cb); });
 	}
 
 	std::future<reply>
 	client::slowlog(const std::string &subcommand, const std::string &argument) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return slowlog(subcommand, argument, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return slowlog(subcommand, argument, cb); });
 	}
 
 	std::future<reply>
 	client::smembers(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return smembers(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return smembers(key, cb); });
 	}
 
 	std::future<reply>
 	client::smove(const std::string &src, const std::string &dst, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return smove(src, dst, member, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return smove(src, dst, member, cb); });
 	}
 
 	std::future<reply>
 	client::sort(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sort(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sort(key, cb); });
 	}
 
 	std::future<reply>
 	client::sort(const std::string &key, const std::vector<std::string> &get_patterns, bool asc_order, bool alpha) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return sort(key, get_patterns, asc_order, alpha, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return sort(key, get_patterns, asc_order, alpha, cb); });
 	}
 
 	std::future<reply>
 	client::sort(const std::string &key, std::size_t offset, std::size_t count,
 	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return sort(key, offset, count, get_patterns, asc_order, alpha, cb);
 		});
 	}
@@ -4329,7 +4329,7 @@ namespace cpp_redis {
 	std::future<reply>
 	client::sort(const std::string &key, const std::string &by_pattern, const std::vector<std::string> &get_patterns,
 	             bool asc_order, bool alpha) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return sort(key, by_pattern, get_patterns, asc_order, alpha, cb);
 		});
 	}
@@ -4337,7 +4337,7 @@ namespace cpp_redis {
 	std::future<reply>
 	client::sort(const std::string &key, const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
 	             const std::string &store_dest) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return sort(key, get_patterns, asc_order, alpha, store_dest, cb);
 		});
 	}
@@ -4346,7 +4346,7 @@ namespace cpp_redis {
 	client::sort(const std::string &key, std::size_t offset, std::size_t count,
 	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
 	             const std::string &store_dest) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return sort(key, offset, count, get_patterns, asc_order, alpha, store_dest, cb);
 		});
 	}
@@ -4354,7 +4354,7 @@ namespace cpp_redis {
 	std::future<reply>
 	client::sort(const std::string &key, const std::string &by_pattern, const std::vector<std::string> &get_patterns,
 	             bool asc_order, bool alpha, const std::string &store_dest) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return sort(key, by_pattern, get_patterns, asc_order, alpha, store_dest, cb);
 		});
 	}
@@ -4362,7 +4362,7 @@ namespace cpp_redis {
 	std::future<reply>
 	client::sort(const std::string &key, const std::string &by_pattern, std::size_t offset, std::size_t count,
 	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return sort(key, by_pattern, offset, count, get_patterns, asc_order, alpha, cb);
 		});
 	}
@@ -4371,155 +4371,155 @@ namespace cpp_redis {
 	client::sort(const std::string &key, const std::string &by_pattern, std::size_t offset, std::size_t count,
 	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
 	             const std::string &store_dest) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return sort(key, by_pattern, offset, count, get_patterns, asc_order, alpha, store_dest, cb);
 		});
 	}
 
 	std::future<reply>
 	client::spop(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return spop(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return spop(key, cb); });
 	}
 
 	std::future<reply>
 	client::spop(const std::string &key, int count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return spop(key, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return spop(key, count, cb); });
 	}
 
 	std::future<reply>
 	client::srandmember(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return srandmember(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return srandmember(key, cb); });
 	}
 
 	std::future<reply>
 	client::srandmember(const std::string &key, int count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return srandmember(key, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return srandmember(key, count, cb); });
 	}
 
 	std::future<reply>
 	client::srem(const std::string &key, const std::vector<std::string> &members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return srem(key, members, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return srem(key, members, cb); });
 	}
 
 	std::future<reply>
 	client::sscan(const std::string &key, std::size_t cursor) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sscan(key, cursor, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sscan(key, cursor, cb); });
 	}
 
 	std::future<reply>
 	client::sscan(const std::string &key, std::size_t cursor, const std::string &pattern) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sscan(key, cursor, pattern, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sscan(key, cursor, pattern, cb); });
 	}
 
 	std::future<reply>
 	client::sscan(const std::string &key, std::size_t cursor, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sscan(key, cursor, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sscan(key, cursor, count, cb); });
 	}
 
 	std::future<reply>
 	client::sscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sscan(key, cursor, pattern, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sscan(key, cursor, pattern, count, cb); });
 	}
 
 	std::future<reply>
 	client::strlen(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return strlen(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return strlen(key, cb); });
 	}
 
 	std::future<reply>
 	client::sunion(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sunion(keys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sunion(keys, cb); });
 	}
 
 	std::future<reply>
 	client::sunionstore(const std::string &dst, const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sunionstore(dst, keys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sunionstore(dst, keys, cb); });
 	}
 
 	std::future<reply>
 	client::sync() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sync(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return sync(cb); });
 	}
 
 	std::future<reply>
 	client::time() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return time(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return time(cb); });
 	}
 
 	std::future<reply>
 	client::ttl(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return ttl(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return ttl(key, cb); });
 	}
 
 	std::future<reply>
 	client::type(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return type(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return type(key, cb); });
 	}
 
 	std::future<reply>
 	client::unwatch() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return unwatch(cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return unwatch(cb); });
 	}
 
 	std::future<reply>
 	client::wait(int numslaves, int timeout) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return wait(numslaves, timeout, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return wait(numslaves, timeout, cb); });
 	}
 
 	std::future<reply>
 	client::watch(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return watch(keys, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return watch(keys, cb); });
 	}
 
 	std::future<reply>
 	client::xack(const std::string &key, const std::string &group, const std::vector<std::string> &id_members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return xack(key, group, id_members, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return xack(key, group, id_members, cb); });
 	}
 
 	std::future<reply>
 	client::xadd(const std::string &key, const std::string &id,
 	             const std::multimap<std::string, std::string> &field_members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xadd(key, id, field_members, cb);
 		});
 	}
 
 	std::future<reply> client::xclaim(const std::string &key, const std::string &group, const std::string &consumer,
 	                                  const int &min_idle_time, const std::vector<std::string> &id_members, const xclaim_options_t &options) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xclaim(key, group, consumer, min_idle_time, id_members, options, cb);
 		});
 	}
 
 	std::future<reply> client::xdel(const std::string &key, const std::vector<std::string> &id_members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xdel(key, id_members, cb);
 		});
 	}
 
 	std::future<reply>
 	client::xgroup_create(const std::string &key, const std::string &group_name, const std::string &id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xgroup_create(key, group_name, id, cb);
 		});
 	}
 
 	std::future<reply>
 	client::xgroup_set_id(const std::string &key, const std::string &group_name, const std::string &id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xgroup_set_id(key, group_name, id, cb);
 		});
 	}
 
 	std::future<reply> client::xgroup_destroy(const std::string &key, const std::string &group_name) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xgroup_destroy(key, group_name, cb);
 		});
 	}
 
 	std::future<reply>
 	client::xgroup_del_consumer(const std::string &key, const std::string &group_name, const std::string &consumer_name) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xgroup_del_consumer(key, group_name, consumer_name, cb);
 		});
 	}
@@ -4531,25 +4531,25 @@ namespace cpp_redis {
 	 * @return
 	 */
 	std::future<reply> client::xinfo_consumers(const std::string &key, const std::string &group_name) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xinfo_consumers(key, group_name, cb);
 		});
 	}
 
 	std::future<reply> client::xinfo_groups(const std::string &stream) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xinfo_groups(stream, cb);
 		});
 	}
 
 	std::future<reply> client::xinfo_stream(const std::string &stream) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xinfo_stream(stream, cb);
 		});
 	}
 
 	std::future<reply> client::xlen(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xlen(key, cb);
 		});
 	}
@@ -4557,42 +4557,42 @@ namespace cpp_redis {
 	std::future<reply> client::xpending(const std::string &stream,
 	                            const std::string &group,
 	                            const xpending_options_t &options) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xpending(stream, group, options, cb);
 		});
 	}
 
 	std::future<reply> client::xrange(const std::string &stream, const range_options_t &range_args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xrange(stream, range_args, cb);
 		});
 	}
 
 	std::future<reply> client::xreadgroup(const xreadgroup_options_t &a) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xreadgroup(a, cb);
 		});
 	}
 
 	std::future<reply> client::xread(const xread_options_t &a) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xread(a, cb);
 		});
 	}
 
 	std::future<reply> client::xrevrange(const std::string &key, const range_options_t &range_args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xrevrange(key, range_args, cb);
 		});
 	}
 
 	std::future<reply> client::xtrim(const std::string &key, int max_len) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xtrim(key, max_len, cb);
 		});
 	}
 	std::future<reply> client::xtrim_approx(const std::string &key, int max_len) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return xtrim_approx(key, max_len, cb);
 		});
 	}
@@ -4600,110 +4600,110 @@ namespace cpp_redis {
 	std::future<reply>
 	client::zadd(const std::string &key, const std::vector<std::string> &options,
 	             const std::multimap<std::string, std::string> &score_members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zadd(key, options, score_members, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zadd(key, options, score_members, cb); });
 	}
 
 	std::future<reply>
 	client::zcard(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zcard(key, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zcard(key, cb); });
 	}
 
 	std::future<reply>
 	client::zcount(const std::string &key, int min, int max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zcount(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zcount(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zcount(const std::string &key, double min, double max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zcount(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zcount(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zcount(const std::string &key, const std::string &min, const std::string &max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zcount(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zcount(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zincrby(const std::string &key, int incr, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zincrby(key, incr, member, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zincrby(key, incr, member, cb); });
 	}
 
 	std::future<reply>
 	client::zincrby(const std::string &key, double incr, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zincrby(key, incr, member, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zincrby(key, incr, member, cb); });
 	}
 
 	std::future<reply>
 	client::zincrby(const std::string &key, const std::string &incr, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zincrby(key, incr, member, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zincrby(key, incr, member, cb); });
 	}
 
 	std::future<reply>
 	client::zinterstore(const std::string &destination, std::size_t numkeys, const std::vector<std::string> &keys,
 	                    const std::vector<std::size_t> weights, aggregate_method method) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zinterstore(destination, numkeys, keys, weights, method, cb);
 		});
 	}
 
 	std::future<reply>
 	client::zlexcount(const std::string &key, int min, int max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zlexcount(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zlexcount(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zlexcount(const std::string &key, double min, double max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zlexcount(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zlexcount(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zlexcount(const std::string &key, const std::string &min, const std::string &max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zlexcount(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zlexcount(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zpopmin(const std::string& key, int count) {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return zpopmin(key, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t& cb) -> client& { return zpopmin(key, count, cb); });
 	}
 	std::future<reply>
 	client::zpopmax(const std::string& key, int count) {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return zpopmax(key, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t& cb) -> client& { return zpopmax(key, count, cb); });
 	}
 
 	std::future<reply>
 	client::zrange(const std::string &key, int start, int stop, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrange(key, start, stop, withscores, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zrange(key, start, stop, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrange(const std::string &key, double start, double stop, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrange(key, start, stop, withscores, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zrange(key, start, stop, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrange(const std::string &key, const std::string &start, const std::string &stop, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrange(key, start, stop, withscores, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zrange(key, start, stop, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrangebylex(const std::string &key, int min, int max, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrangebylex(key, min, max, withscores, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zrangebylex(key, min, max, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrangebylex(const std::string &key, double min, double max, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrangebylex(key, min, max, withscores, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zrangebylex(key, min, max, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrangebylex(const std::string &key, const std::string &min, const std::string &max, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrangebylex(key, min, max, withscores, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zrangebylex(key, min, max, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrangebylex(const std::string &key, int min, int max, std::size_t offset, std::size_t count,
 	                    bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrangebylex(key, min, max, offset, count, withscores, cb);
 		});
 	}
@@ -4711,7 +4711,7 @@ namespace cpp_redis {
 	std::future<reply>
 	client::zrangebylex(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
 	                    bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrangebylex(key, min, max, offset, count, withscores, cb);
 		});
 	}
@@ -4719,7 +4719,7 @@ namespace cpp_redis {
 	std::future<reply>
 	client::zrangebylex(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
 	                    std::size_t count, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrangebylex(key, min, max, offset, count, withscores, cb);
 		});
 	}
@@ -4727,25 +4727,25 @@ namespace cpp_redis {
 	std::future<reply>
 	client::zrangebyscore(const std::string &key, int min, int max, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrangebyscore(key, min, max, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrangebyscore(key, min, max, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrangebyscore(const std::string &key, double min, double max, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrangebyscore(key, min, max, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrangebyscore(key, min, max, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrangebyscore(const std::string &key, const std::string &min, const std::string &max, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrangebyscore(key, min, max, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrangebyscore(key, min, max, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrangebyscore(const std::string &key, int min, int max, std::size_t offset, std::size_t count,
 	                      bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrangebyscore(key, min, max, offset, count, withscores, cb);
 		});
 	}
@@ -4753,7 +4753,7 @@ namespace cpp_redis {
 	std::future<reply>
 	client::zrangebyscore(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
 	                      bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrangebyscore(key, min, max, offset, count, withscores, cb);
 		});
 	}
@@ -4761,106 +4761,106 @@ namespace cpp_redis {
 	std::future<reply>
 	client::zrangebyscore(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
 	                      std::size_t count, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrangebyscore(key, min, max, offset, count, withscores, cb);
 		});
 	}
 
 	std::future<reply>
 	client::zrank(const std::string &key, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrank(key, member, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zrank(key, member, cb); });
 	}
 
 	std::future<reply>
 	client::zrem(const std::string &key, const std::vector<std::string> &members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrem(key, members, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zrem(key, members, cb); });
 	}
 
 	std::future<reply>
 	client::zremrangebylex(const std::string &key, int min, int max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebylex(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zremrangebylex(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zremrangebylex(const std::string &key, double min, double max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebylex(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zremrangebylex(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zremrangebylex(const std::string &key, const std::string &min, const std::string &max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebylex(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zremrangebylex(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zremrangebyrank(const std::string &key, int start, int stop) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyrank(key, start, stop, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zremrangebyrank(key, start, stop, cb); });
 	}
 
 	std::future<reply>
 	client::zremrangebyrank(const std::string &key, double start, double stop) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyrank(key, start, stop, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zremrangebyrank(key, start, stop, cb); });
 	}
 
 	std::future<reply>
 	client::zremrangebyrank(const std::string &key, const std::string &start, const std::string &stop) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyrank(key, start, stop, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zremrangebyrank(key, start, stop, cb); });
 	}
 
 	std::future<reply>
 	client::zremrangebyscore(const std::string &key, int min, int max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyscore(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zremrangebyscore(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zremrangebyscore(const std::string &key, double min, double max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyscore(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zremrangebyscore(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zremrangebyscore(const std::string &key, const std::string &min, const std::string &max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyscore(key, min, max, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zremrangebyscore(key, min, max, cb); });
 	}
 
 	std::future<reply>
 	client::zrevrange(const std::string &key, int start, int stop, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrange(key, start, stop, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrevrange(key, start, stop, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrevrange(const std::string &key, double start, double stop, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrange(key, start, stop, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrevrange(key, start, stop, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrevrange(const std::string &key, const std::string &start, const std::string &stop, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrange(key, start, stop, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrevrange(key, start, stop, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrevrangebylex(const std::string &key, int max, int min, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebylex(key, max, min, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrevrangebylex(key, max, min, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrevrangebylex(const std::string &key, double max, double min, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebylex(key, max, min, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrevrangebylex(key, max, min, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebylex(key, max, min, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrevrangebylex(key, max, min, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrevrangebylex(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
 	                       bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrevrangebylex(key, max, min, offset, count, withscores, cb);
 		});
 	}
@@ -4868,7 +4868,7 @@ namespace cpp_redis {
 	std::future<reply>
 	client::zrevrangebylex(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
 	                       bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrevrangebylex(key, max, min, offset, count, withscores, cb);
 		});
 	}
@@ -4876,7 +4876,7 @@ namespace cpp_redis {
 	std::future<reply>
 	client::zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
 	                       std::size_t count, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrevrangebylex(key, max, min, offset, count, withscores, cb);
 		});
 	}
@@ -4884,25 +4884,25 @@ namespace cpp_redis {
 	std::future<reply>
 	client::zrevrangebyscore(const std::string &key, int max, int min, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebyscore(key, max, min, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrevrangebyscore(key, max, min, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrevrangebyscore(const std::string &key, double max, double min, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebyscore(key, max, min, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrevrangebyscore(key, max, min, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, bool withscores) {
 		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebyscore(key, max, min, withscores, cb); });
+				[=, this](const reply_callback_t &cb) -> client & { return zrevrangebyscore(key, max, min, withscores, cb); });
 	}
 
 	std::future<reply>
 	client::zrevrangebyscore(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
 	                         bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrevrangebyscore(key, max, min, offset, count, withscores, cb);
 		});
 	}
@@ -4910,7 +4910,7 @@ namespace cpp_redis {
 	std::future<reply>
 	client::zrevrangebyscore(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
 	                         bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrevrangebyscore(key, max, min, offset, count, withscores, cb);
 		});
 	}
@@ -4918,45 +4918,45 @@ namespace cpp_redis {
 	std::future<reply>
 	client::zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
 	                         std::size_t count, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zrevrangebyscore(key, max, min, offset, count, withscores, cb);
 		});
 	}
 
 	std::future<reply>
 	client::zrevrank(const std::string &key, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrevrank(key, member, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zrevrank(key, member, cb); });
 	}
 
 	std::future<reply>
 	client::zscan(const std::string &key, std::size_t cursor) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zscan(key, cursor, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zscan(key, cursor, cb); });
 	}
 
 	std::future<reply>
 	client::zscan(const std::string &key, std::size_t cursor, const std::string &pattern) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zscan(key, cursor, pattern, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zscan(key, cursor, pattern, cb); });
 	}
 
 	std::future<reply>
 	client::zscan(const std::string &key, std::size_t cursor, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zscan(key, cursor, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zscan(key, cursor, count, cb); });
 	}
 
 	std::future<reply>
 	client::zscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zscan(key, cursor, pattern, count, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zscan(key, cursor, pattern, count, cb); });
 	}
 
 	std::future<reply>
 	client::zscore(const std::string &key, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zscore(key, member, cb); });
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & { return zscore(key, member, cb); });
 	}
 
 	std::future<reply>
 	client::zunionstore(const std::string &destination, std::size_t numkeys, const std::vector<std::string> &keys,
 	                    const std::vector<std::size_t> weights, aggregate_method method) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
+		return exec_cmd([=, this](const reply_callback_t &cb) -> client & {
 				return zunionstore(destination, numkeys, keys, weights, method, cb);
 		});
 	}

--- a/sources/core/sentinel.cpp
+++ b/sources/core/sentinel.cpp
@@ -266,7 +266,7 @@ sentinel::sync_commit() {
   try_commit();
   std::unique_lock<std::mutex> lock_callback(m_callbacks_mutex);
   __CPP_REDIS_LOG(debug, "cpp_redis::sentinel waiting for callbacks to complete");
-  m_sync_condvar.wait(lock_callback, [=] { return m_callbacks_running == 0 && m_callbacks.empty(); });
+  m_sync_condvar.wait(lock_callback, [=, this] { return m_callbacks_running == 0 && m_callbacks.empty(); });
   __CPP_REDIS_LOG(debug, "cpp_redis::sentinel finished waiting for callback completion");
   return *this;
 }

--- a/sources/network/tcp_client.cpp
+++ b/sources/network/tcp_client.cpp
@@ -52,7 +52,7 @@ void
 tcp_client::async_read(read_request& request) {
   auto callback = std::move(request.async_read_callback);
 
-  m_client.async_read({request.size, [=](tacopie::tcp_client::read_result& result) {
+  m_client.async_read({request.size, [=, this](tacopie::tcp_client::read_result& result) {
                          if (!callback) {
                            return;
                          }
@@ -66,7 +66,7 @@ void
 tcp_client::async_write(write_request& request) {
   auto callback = std::move(request.async_write_callback);
 
-  m_client.async_write({std::move(request.buffer), [=](tacopie::tcp_client::write_result& result) {
+  m_client.async_write({std::move(request.buffer), [=, this](tacopie::tcp_client::write_result& result) {
                           if (!callback) {
                             return;
                           }


### PR DESCRIPTION
With [0] being approved, implicit capturing of `this` in lambda expressions using capture-default `[=]` is deprecated which can be seen while building ceph where a ton of warnings are generated, like:

```
/home/ceph/src/cpp_redis/sources/core/client.cpp: In lambda function: /home/ceph/src/cpp_redis/sources/core/client.cpp:3726:19: warning: implicit
 capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated] 3726 |
 return exec_cmd([=](const reply_callback_t& cb) -> client& { return wait
 (numslaves, timeout, cb); }); |                   ^
/home/ceph/src/cpp_redis/sources/core/client.cpp:3726:19: note: add
 explicit ‘this’ or ‘*this’ capture
```

This needs to be replaced with `[=, this]` (or `[=, *this]`)

[0] https://open-std.org/JTC1/SC22/WG21/docs/papers/2018/p0806r2.html