### PR TITLE
cmake: use CMAKE_CXX_STANDARD to override the parent project setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,8 @@ if(WIN32)
   add_definitions(-DUNICODE)
   add_definitions(-DWIN32_LEAN_AND_MEAN)
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -W -Wall -Wextra -O3")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W -Wall -Wextra -O3")
+  set(CMAKE_CXX_STANDARD 11)
 endif(WIN32)
 
 


### PR DESCRIPTION
This change should avoid the c++20 warnings which get fired because the `CMAKE_CXX_STANDARD` is inherited from the parent ceph project.

By setting this variable locally we avoid the conflicting settings which currently look like 

```
  FLAGS = -std=c++11 -W -Wall -Wextra -O3 -g -g -std=c++20 
```

in the generated ceph build.ninja, resulting in [pipeline build failures](https://jenkins.ceph.com/job/ceph-api/67970/consoleFull#-1418442052a811ea2-3e7b-466b-84b4-d13df7e35809) 